### PR TITLE
sharePoint_upload.sh: remove 'Authorization: Bearer ...' header

### DIFF
--- a/sharePoint_upload.sh
+++ b/sharePoint_upload.sh
@@ -51,7 +51,6 @@ FILENAME=$(echo $1 | sed 's|.*\/||')
 
 curl -b cookies \
      -H "X-RequestDigest: ${DIGEST}" \
-     -H "Authorization: Bearer + ${stoken}" \
      -H "Accept: application/json;odata=verbose" \
      -H "Content-Type: multipart/form-data" \
      -T "${1}" \


### PR DESCRIPTION
This header is broken for two reasons: firstly it attempts to concatenate the stoken variable into the header (which is empty), and secondly the presence of this line causes Sharepoint Online to return a "Unsupported security token" error. It is likely this is because the SP Online logic has changed such that the token in the 'Authorization: Bearer ...' always takes priority over the authentication cookies if both are present.